### PR TITLE
Use info from zarr.Group / zarr.Array to determine endpoints

### DIFF
--- a/simple_zarr_server/_tests/test_simple_zarr_server.py
+++ b/simple_zarr_server/_tests/test_simple_zarr_server.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import zarr
 from simple_zarr_server.server import create_zarr_server
@@ -22,29 +23,35 @@ class HTTPStore:
 
     def __setitem__(self, path, cdata):
         r = self.client.put(f"/{path}", cdata)
+        if not r.ok:
+            raise ValueError
 
 
-def test_numpy_read():
+def test_numpy_read_only():
     # Create data
     original = np.random.rand(1024, 1024)
-    z = zarr.array(original)
+    z = zarr.array(original, read_only=True)
 
     # Initialize app
-    app = create_zarr_server(z.store)
+    app = create_zarr_server(z)
 
     # Open remote array and compare
     remote_store = HTTPStore(TestClient(app))
     arr = zarr.open_array(remote_store)
     np.testing.assert_allclose(arr[:], original)
 
+    # Make sure can't write
+    with pytest.raises(ValueError):
+        arr[:50, :50] = 10
 
-def test_numpy_write():
+
+def test_numpy_writeable():
     # Create data
     original = np.random.rand(1024, 1024)
     mutable = zarr.array(original)
 
     # Initialize app
-    app = create_zarr_server(mutable.store, writeable=True)
+    app = create_zarr_server(mutable)
 
     # Open remote array and compare
     remote_store = HTTPStore(TestClient(app))
@@ -52,3 +59,18 @@ def test_numpy_write():
     arr[:50, :50] = 2
 
     np.testing.assert_allclose(arr[:], mutable[:])
+
+
+def test_nested_array():
+    # Create zarr hierarchy
+    original = np.random.rand(1024, 1024)
+    grp = zarr.open()
+    grp.create_dataset("nested", data=original)
+
+    # Intitilize app with nested nested array
+    app = create_zarr_server(grp.get("nested"))
+
+    # Ensure indexing works
+    remote_store = HTTPStore(TestClient(app))
+    arr = zarr.open_array(remote_store)
+    np.testing.assert_allclose(arr[:], original)

--- a/simple_zarr_server/cli.py
+++ b/simple_zarr_server/cli.py
@@ -16,7 +16,12 @@ LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"]
 
 @click.command()
 @click.argument("path", type=click.Path(exists=True))
-@click.option("--allow-write", "-w", is_flag=True)
+@click.option(
+    "--allow-write",
+    "-w",
+    help="Whether to allow PUT requests and enable write to underlying store.",
+    is_flag=True,
+)
 # These options are mostly copied from uvicorn's docs
 @click.option(
     "--host",
@@ -90,7 +95,7 @@ def main(
     use_colors,
 ):
     # Handles opening .n5, .zip, and .zarr extensions
-    z = zarr.open(path)
+    z = zarr.open(path, mode="a" if allow_write else "r")
     config = {
         "host": host,
         "port": port,
@@ -103,4 +108,4 @@ def main(
         "forwarded_allow_ips": forwarded_allow_ips,
         "use_colors": use_colors,
     }
-    serve(z, writeable=allow_write, **config)
+    serve(z, **config)


### PR DESCRIPTION
Originally a `writeable` flag was used in `create_zarr_server` to determine whether to enable `PUT` requests. This PR removes this flag and instead inspects the `read_only` property on the `zarr.Array` or `zarr.Group` to determine which endpoints to expose. 

In addition, this PR enables serving nested arrays. Previously the entire store was accessible via HTTP, but now only children of a `zarr.Array` or `zarr.Group` are available at the endpoint. This fixes some odd behavior where the client would need to traverse the whole hierarchy even if a nested array was provided to `serve`.

```python
# server
import zarr 
import numpy as np
from simple_zarr_server import serve

grp = zarr.open()
sample = grp.create_dataset('sample', data=np.random.rand(5,5))
serve(sample)

# previous client
da.from_zarr("http://localhost:8000") 
# ValueError: array not found at path ''
da.from_zarr("http://localhost:8000/sample")
# dask.array<from-zarr, shape=(5, 5), dtype=float64, chunksize=(5, 5), chunktype=numpy.ndarray>

#  current client
da.from_zarr("http://localhost:8000") # nested array is served from root of URL
# dask.array<from-zarr, shape=(5, 5), dtype=float64, chunksize=(5, 5), chunktype=numpy.ndarray>
```

