### PR TITLE
Enable named endpoint prefix

### DIFF
--- a/simple_zarr_server/__init__.py
+++ b/simple_zarr_server/__init__.py
@@ -3,4 +3,4 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-from .server import serve, create_zarr_server
+from .server import serve, create_zarr_route

--- a/simple_zarr_server/_tests/test_simple_zarr_server.py
+++ b/simple_zarr_server/_tests/test_simple_zarr_server.py
@@ -1,8 +1,9 @@
 import pytest
 import numpy as np
 import zarr
-from simple_zarr_server.server import create_zarr_server
+from simple_zarr_server.server import create_zarr_route
 from starlette.testclient import TestClient
+from starlette.applications import Starlette
 
 
 class HTTPStore:
@@ -33,7 +34,8 @@ def test_numpy_read_only():
     z = zarr.array(original, read_only=True)
 
     # Initialize app
-    app = create_zarr_server(z)
+    route = create_zarr_route(z)
+    app = Starlette(routes=[route])
 
     # Open remote array and compare
     remote_store = HTTPStore(TestClient(app))
@@ -51,7 +53,8 @@ def test_numpy_writeable():
     mutable = zarr.array(original)
 
     # Initialize app
-    app = create_zarr_server(mutable)
+    route = create_zarr_route(mutable)
+    app = Starlette(routes=[route])
 
     # Open remote array and compare
     remote_store = HTTPStore(TestClient(app))
@@ -68,7 +71,8 @@ def test_nested_array():
     grp.create_dataset("nested", data=original)
 
     # Intitilize app with nested nested array
-    app = create_zarr_server(grp.get("nested"))
+    route = create_zarr_route(grp.get("nested"))
+    app = Starlette(routes=[route])
 
     # Ensure indexing works
     remote_store = HTTPStore(TestClient(app))


### PR DESCRIPTION
Adds the `name` argument to `serve`. This allows you to prefix any store with a custom path.

```python
import zarr
from simple_zarr_server import serve

grp = zarr.open()
grp.attrs['hello'] = 'world'

serve(grp)
# zgrp available at `http://localhost:8000/`

serve(grp, name='data.zarr')
# zgrp avaiable at `http://localhost:8000/data.zarr/`
```

```javascript
fetch('http://localhost:8000/data.zarr/.zattrs')
  .then(res => res.json())
  .then(console.log);
// { hello: 'world' }
```